### PR TITLE
[FEAT] 요구사항 2E 구현 - 연혁 열람 기능 추가 (관리자 메뉴, 사용자 메뉴)

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="homebrew-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="openjdk-22" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/main/java/AdminInterface.java
+++ b/src/main/java/AdminInterface.java
@@ -2,6 +2,7 @@ import manager.BookManager;
 import manager.MemoryBookManager;
 import models.*;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
@@ -10,9 +11,11 @@ public class AdminInterface {
     private Admin admin;
     private Scanner scanner;
     private BookManager bookManager = MemoryBookManager.getInstance();
+    private LocalDate currentDate; // 현재 날짜 필드 추가
 
-    public AdminInterface(Admin admin) {
+    public AdminInterface(Admin admin, LocalDate currentDate) {
         this.admin = admin;
+        this.currentDate = currentDate; // 전달받은 날짜 저장
         this.scanner = new Scanner(System.in);
     }
 
@@ -184,6 +187,9 @@ public class AdminInterface {
         String confirm = scanner.nextLine();
         if ("y".equals(confirm)) {
             Book newBook = bookManager.addBook(title, authors, quantity);
+            for (BookCopy copy : newBook.getCopies()) {
+                copy.setAddedDate(currentDate); // 입고일 설정
+            }
             bookManager.saveData();
             System.out.println("도서가 성공적으로 추가되었습니다. 도서 ID는 [" + newBook.getId() + "]입니다.");
         } else {
@@ -231,7 +237,7 @@ public class AdminInterface {
             }
         }
 
-        book.addCopies(copiesToAdd);
+        book.addCopies(copiesToAdd, currentDate);
         bookManager.saveData();
         System.out.println("사본이 성공적으로 추가되었습니다. 관리자 메뉴 화면으로 이동합니다.");
     }

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -118,7 +118,7 @@ public class Main {
 
                     if (account instanceof Admin) {
                         System.out.println("관리자 권한으로 접속합니다. 관리자 메뉴화면으로 이동합니다.");
-                        AdminInterface adminInterface = new AdminInterface((Admin) account);
+                        AdminInterface adminInterface = new AdminInterface((Admin) account, tempDate);
                         adminInterface.showMenu();
                     } else if (account instanceof User) {
                         System.out.println("사용자 권한으로 접속합니다. 사용자 메뉴화면으로 이동합니다.");

--- a/src/main/java/UserInterface.java
+++ b/src/main/java/UserInterface.java
@@ -161,7 +161,7 @@ public class UserInterface {
             int borrowPeriod = bookManager.getBorrowPeriod();
             LocalDate scheduledReturnDate = borrowDate.plusDays(borrowPeriod);
             bookCopy.borrow();
-            BorrowRecord newBorrowRecord = new BorrowRecord(user.getId(), bookCopy.getBookId(), bookCopy.getCopyId(),borrowDate, scheduledReturnDate);
+            BorrowRecord newBorrowRecord = new BorrowRecord(user.getId(), bookCopy.getBookId(), bookCopy.getCopyId(), borrowDate, scheduledReturnDate);
 
             user.addBorrowRecord(newBorrowRecord);
             bookManager.saveData();
@@ -266,45 +266,49 @@ public class UserInterface {
                 return;
             }
 
-            // 도서 연혁 출력
-            System.out.println("--------------------------------------------------------------------------");
-            Book book = bookManager.getBookById(bookCopy.getBookId());
-            String authors = book.getAuthors().stream()
-                    .map(Author::getName)
-                    .reduce((a, b) -> a + ", " + b)
-                    .orElse("no author");
-            System.out.printf("도서: %s (저자: %s)%n", book.getTitle(), authors);
+            // 삭제일 출력
+            LocalDate deletedDate = bookCopy.getDeletedDate();
+            if (deletedDate != null) {
+                System.out.println("입력하신 ID에 해당하는 도서 사본은 삭제되었습니다.");
+            } else {           // 도서 연혁 출력
+                System.out.println("--------------------------------------------------------------------------");
+                Book book = bookManager.getBookById(bookCopy.getBookId());
+                String authors = book.getAuthors().stream()
+                        .map(Author::getName)
+                        .reduce((a, b) -> a + ", " + b)
+                        .orElse("no author");
+                System.out.printf("도서: %s (저자: %s)%n", book.getTitle(), authors);
 
-            // 입고일 출력
-            System.out.printf("입고일: %s%n", bookCopy.getAddedDate() != null ? bookCopy.getAddedDate() : "알 수 없음");
+                // 입고일 출력
+                System.out.printf("입고일: %s%n", bookCopy.getAddedDate() != null ? bookCopy.getAddedDate() : "알 수 없음");
 
-            // 대출/반납 기록 출력
-            System.out.println("대출/반납 기록:");
-            List<BorrowRecord> borrowRecords = bookManager.getBorrowRecordsByCopyId(bookCopyId);
-            List<ReturnRecord> returnRecords = bookManager.getReturnRecordsByCopyId(bookCopyId);
+                // 대출/반납 기록 출력
+                System.out.println("대출/반납 기록:");
+                List<BorrowRecord> borrowRecords = bookManager.getBorrowRecordsByCopyId(bookCopyId);
+                List<ReturnRecord> returnRecords = bookManager.getReturnRecordsByCopyId(bookCopyId);
 
-            for (BorrowRecord borrowRecord : borrowRecords) {
-                System.out.println("[대출]");
-                System.out.printf("- 대출자 ID: %s%n", borrowRecord.getUserId());
-                System.out.printf("- 대출 날짜: %s%n", borrowRecord.getBorrowDate());
-                System.out.printf("- 반납 기한: %s%n", borrowRecord.getScheduledReturnDate());
+                for (BorrowRecord borrowRecord : borrowRecords) {
+                    System.out.println("[대출]");
+                    System.out.printf("- 대출자 ID: %s%n", borrowRecord.getUserId());
+                    System.out.printf("- 대출 날짜: %s%n", borrowRecord.getBorrowDate());
+                    System.out.printf("- 반납 기한: %s%n", borrowRecord.getScheduledReturnDate());
 
-                // 대응되는 반납 기록 확인
-                ReturnRecord correspondingReturnRecord = returnRecords.stream()
-                        .filter(returnRecord -> returnRecord.getCopyId() == borrowRecord.getCopyId() &&
-                                !returnRecord.getReturnDate().isBefore(borrowRecord.getBorrowDate()))
-                        .findFirst()
-                        .orElse(null);
+                    // 대응되는 반납 기록 확인
+                    ReturnRecord correspondingReturnRecord = returnRecords.stream()
+                            .filter(returnRecord -> returnRecord.getCopyId() == borrowRecord.getCopyId() &&
+                                    !returnRecord.getReturnDate().isBefore(borrowRecord.getBorrowDate()))
+                            .findFirst()
+                            .orElse(null);
 
-                if (correspondingReturnRecord != null) {
-                    System.out.println("[반납]");
-                    System.out.printf("- 반납 날짜: %s%n", correspondingReturnRecord.getReturnDate());
-                } else {
-                    System.out.println("- 현재 대출 중");
+                    if (correspondingReturnRecord != null) {
+                        System.out.println("[반납]");
+                        System.out.printf("- 반납 날짜: %s%n", correspondingReturnRecord.getReturnDate());
+                    } else {
+                        System.out.println("- 현재 대출 중");
+                    }
                 }
             }
 
-            System.out.println("--------------------------------------------------------------------------");
             System.out.println("사용자 메뉴 화면으로 이동합니다.");
             return;
         }

--- a/src/main/java/manager/BookManager.java
+++ b/src/main/java/manager/BookManager.java
@@ -5,6 +5,7 @@ import models.BookCopy;
 import record.BorrowRecord;
 import record.ReturnRecord;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface BookManager {
@@ -12,7 +13,7 @@ public interface BookManager {
     public Book addBook(String title, List<String> authors, int quantity);
 
     // 도서 삭제 메서드
-    public void removeBookCopy(int copyId);
+    public void removeBookCopy(int copyId, LocalDate removeDate);
 
     // 도서 ID로 검색
     public Book getBookById(int id);

--- a/src/main/java/manager/BookManager.java
+++ b/src/main/java/manager/BookManager.java
@@ -2,6 +2,8 @@ package manager;
 
 import models.Book;
 import models.BookCopy;
+import record.BorrowRecord;
+import record.ReturnRecord;
 
 import java.util.List;
 
@@ -31,5 +33,16 @@ public interface BookManager {
 
     int getBorrowPeriod();
 
+    // 대출 기록 조회
+    List<BorrowRecord> getBorrowRecordsByCopyId(int copyId);
+
+    // 반납 기록 조회
+    List<ReturnRecord> getReturnRecordsByCopyId(int copyId);
+
+    // 대출 기록 추가
+    void addBorrowRecord(BorrowRecord record);
+
+    // 반납 기록 추가
+    void addReturnRecord(ReturnRecord record);
 
 }

--- a/src/main/java/manager/MemoryBookManager.java
+++ b/src/main/java/manager/MemoryBookManager.java
@@ -5,6 +5,8 @@ import java.util.HashMap;
 import java.util.List;
 
 import models.*;
+import record.BorrowRecord;
+import record.ReturnRecord;
 
 import java.util.ArrayList;
 
@@ -16,6 +18,9 @@ public class MemoryBookManager implements Serializable, BookManager {
     private final String FILE_PATH = "books.post";
 
     private int borrowPeriod = 7; // 최초 기본 7일
+
+    private List<BorrowRecord> borrowRecords = new ArrayList<>();
+    private List<ReturnRecord> returnRecords = new ArrayList<>();
 
     private MemoryBookManager() {
         books = new HashMap<>();
@@ -158,5 +163,33 @@ public class MemoryBookManager implements Serializable, BookManager {
 
     public int getBorrowPeriod() {
         return borrowPeriod;
+    }
+
+    public List<BorrowRecord> getBorrowRecordsByCopyId(int copyId) {
+        List<BorrowRecord> result = new ArrayList<>();
+        for (BorrowRecord record : borrowRecords) {
+            if (record.getCopyId() == copyId) {
+                result.add(record);
+            }
+        }
+        return result;
+    }
+
+    public List<ReturnRecord> getReturnRecordsByCopyId(int copyId) {
+        List<ReturnRecord> result = new ArrayList<>();
+        for (ReturnRecord record : returnRecords) {
+            if (record.getCopyId() == copyId) {
+                result.add(record);
+            }
+        }
+        return result;
+    }
+
+    public void addBorrowRecord(BorrowRecord record) {
+        borrowRecords.add(record);
+    }
+
+    public void addReturnRecord(ReturnRecord record) {
+        returnRecords.add(record);
     }
 }

--- a/src/main/java/manager/MemoryBookManager.java
+++ b/src/main/java/manager/MemoryBookManager.java
@@ -1,6 +1,7 @@
 package manager;
 
 import java.io.*;
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
 
@@ -21,6 +22,7 @@ public class MemoryBookManager implements Serializable, BookManager {
 
     private List<BorrowRecord> borrowRecords = new ArrayList<>();
     private List<ReturnRecord> returnRecords = new ArrayList<>();
+    private List<BookCopy> deletedCopies = new ArrayList<>();
 
     private MemoryBookManager() {
         books = new HashMap<>();
@@ -89,11 +91,14 @@ public class MemoryBookManager implements Serializable, BookManager {
     }
 
     // 도서 사본 삭제 메서드
-    public void removeBookCopy(int copyId) {
+    public void removeBookCopy(int copyId, LocalDate currentDate) {
         for (Book book : books.values()) {
             List<BookCopy> copies = book.getCopies();
             for (int i = 0; i < copies.size(); i++) {
                 if (copies.get(i).getCopyId() == copyId) {
+                    BookCopy deletedCopy = copies.get(i);
+                    deletedCopy.setDeletedDate(currentDate);
+                    deletedCopies.add(deletedCopy);
                     copies.remove(i);
                     saveData(); // 도서 사본 삭제 시 저장
                     return;
@@ -113,6 +118,12 @@ public class MemoryBookManager implements Serializable, BookManager {
                 if (copy.getCopyId() == bookCopyId) {
                     return copy;
                 }
+            }
+        }
+
+        for (BookCopy copy: deletedCopies){
+            if (copy.getCopyId() == bookCopyId){
+                return copy;
             }
         }
         return null;

--- a/src/main/java/models/Book.java
+++ b/src/main/java/models/Book.java
@@ -1,6 +1,7 @@
 package models;
 
 import java.io.Serializable;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -18,7 +19,7 @@ public class Book implements Serializable {
         this.title = title + " (" + num + ")";
         this.authors = authors.isEmpty() ? List.of(new Author("no author", -1)) : new ArrayList<>(authors);
         this.copies = new ArrayList<>();
-        addCopies(quantity);  // 초기 복사본 생성
+        addCopies(quantity, null);  // 초기 복사본 생성
     }
 
     // Getter 메서드
@@ -39,9 +40,11 @@ public class Book implements Serializable {
     }
 
     // 새 복사본 추가 메서드
-    public void addCopies(int quantity) {
+    public void addCopies(int quantity, LocalDate addedDate) {
         for (int i = 0; i < quantity; i++) {
-            copies.add(new BookCopy(this.id));
+            BookCopy copy = new BookCopy(this.id);
+            copy.setAddedDate(addedDate); // 입고일 설정
+            copies.add(copy);
         }
     }
 

--- a/src/main/java/models/BookCopy.java
+++ b/src/main/java/models/BookCopy.java
@@ -13,12 +13,14 @@ public class BookCopy implements Serializable {
     private LocalDate returnDate;
     private int bookId;
     private LocalDate addedDate;
+    private LocalDate deletedDate;
 
     public BookCopy(int bookId) {
         this.copyId = nextCopyId++;
         this.isBorrowed = false;
         this.bookId = bookId;
         this.addedDate = LocalDate.now();
+        this.deletedDate = null;
     }
 
     public int getCopyId() {
@@ -40,6 +42,7 @@ public class BookCopy implements Serializable {
     public void setReturnDate(LocalDate returnDate) {
         this.returnDate = returnDate;
     }
+
     public LocalDate getReturnDate() {
         return returnDate;
     }
@@ -54,5 +57,13 @@ public class BookCopy implements Serializable {
 
     public void setAddedDate(LocalDate addedDate) {
         this.addedDate = addedDate;
+    }
+
+    public LocalDate getDeletedDate() {
+        return deletedDate;
+    }
+
+    public void setDeletedDate(LocalDate deletedDate) {
+        this.deletedDate = deletedDate;
     }
 }

--- a/src/main/java/models/BookCopy.java
+++ b/src/main/java/models/BookCopy.java
@@ -12,11 +12,13 @@ public class BookCopy implements Serializable {
     private boolean isBorrowed;
     private LocalDate returnDate;
     private int bookId;
+    private LocalDate addedDate;
 
     public BookCopy(int bookId) {
         this.copyId = nextCopyId++;
         this.isBorrowed = false;
         this.bookId = bookId;
+        this.addedDate = LocalDate.now();
     }
 
     public int getCopyId() {
@@ -44,5 +46,13 @@ public class BookCopy implements Serializable {
 
     public int getBookId() {
         return bookId;
+    }
+
+    public LocalDate getAddedDate() {
+        return addedDate;
+    }
+
+    public void setAddedDate(LocalDate addedDate) {
+        this.addedDate = addedDate;
     }
 }


### PR DESCRIPTION
## ✏️ Work Description
### 요구사항 2E 구현
각 사본(물리적 책)마다 연혁(입고일, 대출/반납기록 등)을 열람할 수 있게 해주세요. 삭제된 사본도 조회할 수 있어야 합니다.

#### 1. 연혁 열람 기능 메뉴 추가
- `사용자`, `관리자` 둘다
- `사용자` - 입고일, 대출기록, 반납기록
- `관리자` - 입고일, 대출기록, 반납기록, 삭제일

#### 2. 연혁 열람 기록은 누적 형식

#### 3. (연혁 열람 기능 메뉴에서) 삭제 사본 조회도 가능
- `관리자`만 가능
    -> 입고일, 대출기록, 반납기록, 삭제일
- `사용자`가 삭제 사본의 연혁을 열람하려 하면, ‘그 사본은 삭제됨’ 메시지 띄움
- (`관리자`, `사용자`) 모두 삭제가 아닌 처음부터 존재하지 않았던 사본은 “그런 사본은 없음” 메시지 띄움

## 📷 Screenshot
**[관리자 메뉴]**
![image](https://github.com/user-attachments/assets/7aa22e06-0c3b-4f98-96b1-fc66e9593599)
![image](https://github.com/user-attachments/assets/8331cb33-fa0a-40c1-a13d-ab30fd86cd35)


**[사용자 메뉴]**
![image](https://github.com/user-attachments/assets/da38ba90-89a3-4e18-aea5-c6548648c0f5)
![image](https://github.com/user-attachments/assets/ee2947da-7441-4d5c-9ec7-3876d2a565b1)
![image](https://github.com/user-attachments/assets/dd084ae1-cd42-41bc-b45d-0e45e4864f91)